### PR TITLE
ci: Add Dependabot configuration for GitHub Actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,16 @@
+version: 2
+
+updates:
+  - package-ecosystem: "github-actions"
+    directories:
+      - "/"
+    commit-message:
+      prefix: "deps(github-actions)"
+    schedule:
+      interval: "daily"
+    target-branch: "main"
+    groups:
+      github-actions:
+        patterns:
+          - "*"
+


### PR DESCRIPTION
# Pull Request

## Description

This change introduces a Dependabot configuration file (`.github/dependabot.yml`) to automate dependency updates for GitHub Actions. The configuration sets up daily checks for updates, targets the main branch, and groups all GitHub Actions updates together. Commit messages for these updates will be prefixed with "deps(github-actions)".

fixes #27