### PR TITLE
ci: Add Justfile format check to code quality workflow

### DIFF
--- a/.github/workflows/code-quality.yml
+++ b/.github/workflows/code-quality.yml
@@ -48,3 +48,18 @@ jobs:
           VALIDATE_TYPESCRIPT_STANDARD: false
           VALIDATE_TSX: false
           VALIDATE_TSX_PRETTIER: false
+
+  check-justfile-format:
+    name: Check Justfile Format
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Set up Just
+        uses: extractions/setup-just@v2
+
+      - name: Check Justfile Format
+        run: just format-check

--- a/Justfile
+++ b/Justfile
@@ -1,0 +1,33 @@
+# ------------------------------------------------------------------------------
+# Prettier - File Formatting
+# ------------------------------------------------------------------------------
+
+# Check for prettier issues
+prettier-check:
+    prettier . --check
+
+# Fix prettier issues
+prettier-format:
+    prettier . --check --write
+
+# ------------------------------------------------------------------------------
+# Justfile
+# ------------------------------------------------------------------------------
+
+# Format the Just code
+format:
+    just --fmt --unstable
+
+# Check for Just format issues
+format-check:
+    just --fmt --check --unstable
+
+# ------------------------------------------------------------------------------
+# Git Hooks
+# ------------------------------------------------------------------------------
+
+# Install pre commit hook to run on all commits
+install-git-hooks:
+    cp -f githooks/pre-commit .git/hooks/pre-commit
+    cp -f githooks/post-commit .git/hooks/post-commit
+    chmod ug+x .git/hooks/*


### PR DESCRIPTION
# Pull Request

## Description

This PR introduces new automation and code quality enhancements:

1. Added a new GitHub Actions job `check-justfile-format` to the `code-quality.yml` workflow. This job checks the formatting of the Justfile using the `just format-check` command.

2. Created a new `Justfile` with various commands:
   - Prettier formatting checks and fixes
   - Just formatting and format checking
   - Installation of git hooks

3. Included commands in the Justfile for installing pre-commit and post-commit hooks.

These changes aim to improve code quality, consistency, and automate formatting checks for the Justfile.

fixes #21