### PR TITLE
ci: Add Markdown link checker to code quality workflow

### DIFF
--- a/.github/other-configurations/.linkspector.yml
+++ b/.github/other-configurations/.linkspector.yml
@@ -1,0 +1,7 @@
+dirs:
+  - ./
+  - ./docs
+excludedFiles:
+  - ./CHANGELOG.md
+aliveStatusCodes:
+  - 200

--- a/.github/workflows/code-quality.yml
+++ b/.github/workflows/code-quality.yml
@@ -49,6 +49,24 @@ jobs:
           VALIDATE_TSX: false
           VALIDATE_TSX_PRETTIER: false
 
+  check-markdown-links:
+    name: Check Markdown links
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Check Markdown links
+        uses: UmbrellaDocs/action-linkspector@v1.2.2
+        with:
+          github_token: ${{ secrets.GH_TOKEN }}
+          config_file: .github/other-configurations/.linkspector.yml
+          reporter: github-pr-review
+          fail_on_error: true
+          filter_mode: nofilter
+
   check-justfile-format:
     name: Check Justfile Format
     runs-on: ubuntu-latest


### PR DESCRIPTION
# Pull Request

## Description

This change introduces a new workflow to check Markdown links and adds a configuration file for the link checker. The modifications include:

1. Added a new `.linkspector.yml` configuration file in the `.github/other-configurations/` directory. This file specifies:
   - Directories to scan for links
   - Files to exclude from scanning
   - Acceptable HTTP status codes for live links

2. Updated the `code-quality.yml` workflow file to include a new job called "Check Markdown links". This job:
   - Uses the UmbrellaDocs/action-linkspector action
   - Configures the action with the newly added `.linkspector.yml` file
   - Sets up GitHub PR review reporting
   - Fails the workflow if any errors are found

These changes will help maintain the integrity of Markdown links throughout the project, ensuring that documentation and references remain up-to-date and functional.

fixes #30