### PR TITLE
chore: Add pyproject.toml for Poetry configuration

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,12 @@
+[tool.poetry]
+name = "tech-detective"
+authors = ["Jack Plowman <62281988+JackPlowman@users.noreply.github.com>"]
+readme = "README.md"
+package-mode = false
+
+[tool.poetry.dependencies]
+python = "^3.13"
+
+[build-system]
+requires = ["poetry-core"]
+build-backend = "poetry.core.masonry.api"


### PR DESCRIPTION
# Pull Request

## Description

This change introduces a `pyproject.toml` file to the project, setting up Poetry as the package management and build system. The file specifies the project name as "tech-detective" and sets the Python version requirement to ^3.13. It also includes basic configuration for the build system, using poetry-core.

fixes #31