### PR TITLE
ci: Add setup-python-dependencies action and update Justfile

### DIFF
--- a/.github/actions/setup-python-dependencies/action.yml
+++ b/.github/actions/setup-python-dependencies/action.yml
@@ -1,0 +1,22 @@
+name: "Setup Dependencies"
+description: "Installs dependencies for the project"
+
+runs:
+  using: "composite"
+  steps:
+    - name: Install Poetry
+      shell: bash
+      run: pipx install poetry==1.8.3
+
+    - name: Install Python 3.13 with Poetry Cache
+      uses: actions/setup-python@v5
+      with:
+        python-version-file: "pyproject.toml"
+        cache: "poetry"
+
+    - name: Set up Just
+      uses: extractions/setup-just@v2
+
+    - name: Install Poetry Dependencies
+      shell: bash
+      run: just install

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,6 +4,7 @@ updates:
   - package-ecosystem: "github-actions"
     directories:
       - "/"
+      - ".github/actions/setup-dependencies"
     commit-message:
       prefix: "deps(github-actions)"
     schedule:

--- a/Justfile
+++ b/Justfile
@@ -1,4 +1,31 @@
 # ------------------------------------------------------------------------------
+# Common Commands
+# ------------------------------------------------------------------------------
+
+# Install python dependencies
+install:
+    poetry install
+
+# ------------------------------------------------------------------------------
+# Cleaning Commands
+# ------------------------------------------------------------------------------
+
+# Remove all cloned repositories and generated files
+clean:
+    find . \( \
+      -name '__pycache__' -o \
+      -name '.coverage' -o \
+      -name '.mypy_cache' -o \
+      -name '.pytest_cache' -o \
+      -name '.ruff_cache' -o \
+      -name '*.pyc' -o \
+      -name '*.pyd' -o \
+      -name '*.pyo' -o \
+      -name 'coverage.xml' -o \
+      -name 'db.sqlite3' \
+    \) -print | xargs rm -rfv
+
+# ------------------------------------------------------------------------------
 # Prettier - File Formatting
 # ------------------------------------------------------------------------------
 


### PR DESCRIPTION
# Pull Request

## Description

This change introduces a new GitHub Action for setting up project dependencies and updates the project structure. Key modifications include:

1. Added a new GitHub Action `setup-dependencies` to streamline the installation of project dependencies:
   - Installs Poetry using pipx
   - Sets up Python 3.13 with Poetry cache
   - Installs Just
   - Runs `just install` to install Poetry dependencies

2. Updated `dependabot.yml` to include the new `setup-dependencies` action directory for GitHub Actions ecosystem updates.

3. Enhanced the `Justfile` with new commands and sections:
   - Added an `install` command to run `poetry install`
   - Introduced a `clean` command to remove various cache and generated files
   - Reorganised the file with clear section headers for better organisation

These changes aim to improve the project's setup process, dependency management, and overall maintainability.

fixes #38