### PR TITLE
ci: Add pre-commit hook for Python code quality

### DIFF
--- a/githooks/pre-commit-scripts/python.sh
+++ b/githooks/pre-commit-scripts/python.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+set -e +x
+
+# Check if there are any changes in the watched folder
+if git diff --cached --name-only | grep -q "^detector/"; then
+  just detector::install
+  just detector::ruff-fix
+fi


### PR DESCRIPTION
# Pull Request

## Description

This change introduces a new pre-commit hook script for Python files. The script is located in the `githooks/pre-commit-scripts/` directory and is named `python.sh`.

The script performs the following actions:
1. Checks if there are any changes in the `detector/` directory.
2. If changes are detected, it runs two commands:
   - `just detector::install`
   - `just detector::ruff-fix`

These commands likely install dependencies and run a linter or formatter on the Python code in the `detector/` directory, ensuring code quality and consistency before commits are made.

This pre-commit hook will help maintain code standards and catch potential issues early in the development process.

fixes #44