### PR TITLE
ci: Add Dependabot configuration for TypeScript dependencies

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -26,3 +26,15 @@ updates:
       python:
         patterns:
           - "*"
+
+  - package-ecosystem: "npm"
+    directory: "dashboard"
+    commit-message:
+      prefix: "deps(typescript)"
+    schedule:
+      interval: "monthly"
+    target-branch: "main"
+    groups:
+      typescript:
+        patterns:
+          - "*"


### PR DESCRIPTION
# Pull Request

## Description

This change adds npm dependency management for the dashboard directory to the Dependabot configuration. The new configuration:

- Sets up monthly checks for npm packages in the dashboard directory
- Uses the prefix "deps(typescript)" for commit messages
- Targets the main branch for updates
- Groups all typescript-related dependencies together

This addition will help keep the dashboard's npm dependencies up-to-date automatically, improving security and ensuring the project uses the latest package versions.

fixes #49