### PR TITLE
chore: Add VSCode settings and update Python linting configuration

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,8 @@
+{
+  "ruff.configuration": "detector/pyproject.toml",
+  "[python]": {
+    "editor.codeActionsOnSave": {
+      "source.fixAll": "explicit"
+    }
+  }
+}

--- a/detector/application/__main__.py
+++ b/detector/application/__main__.py
@@ -1,7 +1,8 @@
 from application.utils.custom_logging import set_up_custom_logging
 
 
-def main():
+def main() -> None:
+    """Main function for the application."""
     set_up_custom_logging()
 
 

--- a/detector/pyproject.toml
+++ b/detector/pyproject.toml
@@ -1,7 +1,4 @@
 [tool.poetry]
-name = "tech-detective"
-authors = ["Jack Plowman <62281988+JackPlowman@users.noreply.github.com>"]
-readme = "README.md"
 package-mode = false
 
 [tool.poetry.dependencies]
@@ -15,3 +12,60 @@ vulture = "2.13"
 [build-system]
 requires = ["poetry-core"]
 build-backend = "poetry.core.masonry.api"
+
+[tool.ruff]
+line-length = 120
+target-version = "py313"
+
+[tool.ruff.lint]
+# Add the `line-too-long` rule to the enforced rule set.
+extend-select = ["E501"]
+select = ["ALL"]
+
+ignore = [
+  "COM812",  # Ignore due to conflict with Ruff formatter
+  "ISC001",  # Ignore due to conflict with Ruff formatter
+  "PLR2004", # Ignore magic value
+  "D104",    # Ignore missing docstring in public package
+  "D100",    # Ignore missing docstring in public module
+  "N999",    # Ignore invalid module name
+  "SIM112",  # Ignore Lowercase environment variables (used for GitHub actions)
+]
+
+# Allow autofix for all enabled rules (when `--fix`) is provided.
+fixable = ["ALL"]
+unfixable = []
+
+# Exclude a variety of commonly ignored directories.
+exclude = [
+  ".bzr",
+  ".direnv",
+  ".eggs",
+  ".git",
+  ".hg",
+  ".mypy_cache",
+  ".nox",
+  ".pants.d",
+  ".pytype",
+  ".ruff_cache",
+  ".svn",
+  ".tox",
+  ".venv",
+  "__pypackages__",
+  "_build",
+]
+
+# Allow unused variables when underscore-prefixed.
+dummy-variable-rgx = "(_+|(_+[a-zA-Z0-9_]*[a-zA-Z0-9]+?))$"
+
+[tool.ruff.lint.per-file-ignores]
+"**test_*.py" = ["S101", "D102", "D103", "SLF001", "PT019"]
+
+[tool.ruff.lint.pydocstyle]
+convention = "google" # Use Google docstring convention.
+
+[tool.ruff.lint.isort]
+known-first-party = ["application"]
+
+[tool.vulture]
+ignore_names = ["side_effect"]


### PR DESCRIPTION
# Pull Request

## Description

This change introduces new configuration files and updates existing ones to improve code quality and development experience:

1. Added a `.vscode/settings.json` file to configure Ruff and enable automatic code fixes on save for Python files.

2. Updated `detector/application/__main__.py`:
   - Added a return type annotation to the `main()` function.
   - Included a docstring for the `main()` function.

3. Significantly expanded `detector/pyproject.toml`:
   - Removed unnecessary metadata fields.
   - Added comprehensive Ruff configuration:
     - Set line length to 120 characters.
     - Targeted Python 3.13.
     - Enabled all linting rules with specific exceptions.
     - Configured file exclusions and per-file rule ignores.
     - Set up Google-style docstring conventions.
     - Configured isort for import sorting.
   - Added Vulture configuration to ignore specific names.

These changes aim to standardise code formatting, enforce consistent styling, and improve overall code quality across the project.

fixes #56