### PR TITLE
ci: Update Dependabot configuration for actions and Python dependencies

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,7 +4,7 @@ updates:
   - package-ecosystem: "github-actions"
     directories:
       - "/"
-      - ".github/actions/setup-dependencies"
+      - ".github/actions/setup-python-dependencies"
     commit-message:
       prefix: "deps(github-actions)"
     schedule:
@@ -16,7 +16,7 @@ updates:
           - "*"
 
   - package-ecosystem: "pip"
-    directory: "/"
+    directory: "detector"
     commit-message:
       prefix: "deps(python)"
     schedule:


### PR DESCRIPTION
# Pull Request

## Description

This change updates the Dependabot configuration to reflect recent project structure changes:

1. The GitHub Actions dependencies path has been updated from `.github/actions/setup-dependencies` to `.github/actions/setup-python-dependencies`.

2. The Python dependencies directory has been changed from the root directory (`/`) to the `detector` subdirectory.

These modifications ensure that Dependabot correctly targets the appropriate directories for dependency updates, aligning with the current project structure.

fixes #65