### PR TITLE
ci: Update GitHub Actions and add GitHub Pages deployment

### DIFF
--- a/.github/workflows/code-quality.yml
+++ b/.github/workflows/code-quality.yml
@@ -17,7 +17,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v4.2.1
         with:
           fetch-depth: 0
 
@@ -54,7 +54,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v4.2.1
         with:
           fetch-depth: 0
 
@@ -75,7 +75,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v4.2.1
         with:
           fetch-depth: 0
 
@@ -103,7 +103,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v4.2.1
         with:
           fetch-depth: 0
 
@@ -121,7 +121,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v4.2.1
         with:
           fetch-depth: 0
 

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -21,7 +21,7 @@ jobs:
         language: [python, javascript]
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v4.2.1
       - name: Initialize CodeQL
         uses: github/codeql-action/init@v3
         with:

--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -11,6 +11,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v4.2.1
       - name: Dependency Review
         uses: actions/dependency-review-action@v4

--- a/.github/workflows/deploy-to-github-pages.yml
+++ b/.github/workflows/deploy-to-github-pages.yml
@@ -1,0 +1,34 @@
+name: Deploy to GitHub Pages
+
+on:
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4.2.1
+      - name: Install, build, and upload site
+        uses: withastro/action@v3.0.0
+        with:
+          path: ./dashboard
+          node-version: 22
+
+  deploy:
+    needs: build
+    runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4.0.5

--- a/.github/workflows/sync-labels.yml
+++ b/.github/workflows/sync-labels.yml
@@ -17,7 +17,7 @@ jobs:
     name: Configure Labels
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v4.2.1
         with:
           fetch-depth: 0
       - uses: micnncim/action-label-syncer@v1.3.0

--- a/dashboard/astro.config.mjs
+++ b/dashboard/astro.config.mjs
@@ -2,4 +2,7 @@
 import { defineConfig } from "astro/config";
 
 // https://astro.build/config
-export default defineConfig({});
+export default defineConfig({
+  site: "https://jackplowman.github.io",
+  base: "tech-detective",
+});


### PR DESCRIPTION
# Pull Request

## Description

This pull request updates the GitHub Actions workflows and configures Astro for GitHub Pages deployment:

1. Updates the `actions/checkout` action to version 4.2.1 across all workflows.

2. Adds a new workflow `deploy-to-github-pages.yml` to automatically build and deploy the Astro site to GitHub Pages when changes are pushed to the main branch.

3. Modifies the Astro configuration in `dashboard/astro.config.mjs` to set the site URL and base path for GitHub Pages deployment:
   - Sets `site` to "https://jackplowman.github.io"
   - Sets `base` to "tech-detective"

These changes prepare the project for automated deployment to GitHub Pages and ensure consistent use of the latest checkout action across workflows.

fixes #170