### PR TITLE
chore: Add optional dependency for Linux rollup

### DIFF
--- a/dashboard/package-lock.json
+++ b/dashboard/package-lock.json
@@ -21,6 +21,9 @@
       "engines": {
         "node": ">=22.8.0",
         "npm": ">=10.0.0"
+      },
+      "optionalDependencies": {
+        "@rollup/rollup-linux-x64-gnu": "4.24.0"
       }
     },
     "node_modules/@ampproject/remapping": {
@@ -875,6 +878,19 @@
       "optional": true,
       "os": [
         "darwin"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-x64-gnu": {
+      "version": "4.24.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.24.0.tgz",
+      "integrity": "sha512-ZXFk7M72R0YYFN5q13niV0B7G8/5dcQ9JDp8keJSfr3GoZeXEoMHP/HlvqROA3OMbMdfr19IjCeNAnPUG93b6A==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
       ]
     },
     "node_modules/@shikijs/core": {

--- a/dashboard/package.json
+++ b/dashboard/package.json
@@ -21,6 +21,9 @@
     "prettier": "3.3.3",
     "prettier-plugin-astro": "0.14.1"
   },
+  "optionalDependencies": {
+    "@rollup/rollup-linux-x64-gnu": "4.24.0"
+  },
   "engines": {
     "npm": ">=10.0.0",
     "node": ">=22.8.0"


### PR DESCRIPTION
# Pull Request

## Description

This change adds an optional dependency `@rollup/rollup-linux-x64-gnu` version 4.24.0 to the `package.json` file. This addition enhances compatibility for Linux x64 GNU systems when using Rollup.

Additionally, there's a minor correction in the `engines` section, where a trailing comma has been added after the `npm` version specification.

These updates ensure better cross-platform support and maintain consistent syntax in the package configuration.

fixes #73