### PR TITLE
ci: Add TypeScript setup action and update workflows

### DIFF
--- a/.github/actions/setup-typescript-dependencies/action.yml
+++ b/.github/actions/setup-typescript-dependencies/action.yml
@@ -1,0 +1,19 @@
+name: "Setup Dependencies"
+description: "Installs dependencies for the project"
+
+runs:
+  using: "composite"
+  steps:
+    - name: Set up Node.js
+      uses: actions/setup-node@v4
+      with:
+        node-version-file: "dashboard/package.json"
+        cache: "npm"
+        cache-dependency-path: "dashboard/package-lock.json"
+
+    - name: Set up Just
+      uses: extractions/setup-just@v2
+
+    - name: Install Node Dependencies
+      shell: bash
+      run: just dashboard::ci-install

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,6 +5,7 @@ updates:
     directories:
       - "/"
       - ".github/actions/setup-python-dependencies"
+      - ".github/actions/setup-typescript-dependencies"
     commit-message:
       prefix: "deps(github-actions)"
     schedule:

--- a/.github/workflows/code-quality.yml
+++ b/.github/workflows/code-quality.yml
@@ -58,7 +58,7 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: Setup Dependencies
+      - name: Setup Python Dependencies
         uses: ./.github/actions/setup-python-dependencies
 
       - name: Check Python Code Quality (Ruff)
@@ -79,18 +79,8 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: Set up Node.js
-        uses: actions/setup-node@v4
-        with:
-          node-version-file: "dashboard/package.json"
-          cache: "npm"
-          cache-dependency-path: "dashboard/package-lock.json"
-
-      - name: Set up Just
-        uses: extractions/setup-just@v2
-
-      - name: Install Node Dependencies
-        run: just dashboard::ci-install
+      - name: Setup TypeScript Dependencies
+        uses: ./.github/actions/setup-typescript-dependencies
 
       - name: Run Prettier
         run: just dashboard::prettier-check

--- a/dashboard/package-lock.json
+++ b/dashboard/package-lock.json
@@ -6,15 +6,15 @@
     "": {
       "name": "dashboard",
       "dependencies": {
-        "@astrojs/check": "^0.9.4",
+        "@astrojs/check": "0.9.4",
         "astro": "4.16.6",
         "typescript": "5.6.3"
       },
       "devDependencies": {
-        "@typescript-eslint/parser": "^8.10.0",
-        "eslint": "^9.12.0",
-        "eslint-plugin-astro": "^1.3.0",
-        "eslint-plugin-jsx-a11y": "^6.10.0",
+        "@typescript-eslint/parser": "8.10.0",
+        "eslint": "9.13.0",
+        "eslint-plugin-astro": "1.3.0",
+        "eslint-plugin-jsx-a11y": "6.10.0",
         "prettier": "3.3.3",
         "prettier-plugin-astro": "0.14.1"
       },
@@ -548,9 +548,9 @@
       }
     },
     "node_modules/@eslint/core": {
-      "version": "0.6.0",
-      "resolved": "https://registry.npmjs.org/@eslint/core/-/core-0.6.0.tgz",
-      "integrity": "sha512-8I2Q8ykA4J0x0o7cg67FPVnehcqWTBehu/lmY+bolPFHGjh49YzGBMXTvpqVgEbBdvNCSxj6iFgiIyHzf03lzg==",
+      "version": "0.7.0",
+      "resolved": "https://registry.npmjs.org/@eslint/core/-/core-0.7.0.tgz",
+      "integrity": "sha512-xp5Jirz5DyPYlPiKat8jaq0EmYvDXKKpzTbxXMpT9eqlRJkRKIz9AGMdlvYjih+im+QlhWrpvVjl8IPC/lHlUw==",
       "dev": true,
       "license": "Apache-2.0",
       "engines": {
@@ -643,9 +643,9 @@
       }
     },
     "node_modules/@eslint/js": {
-      "version": "9.12.0",
-      "resolved": "https://registry.npmjs.org/@eslint/js/-/js-9.12.0.tgz",
-      "integrity": "sha512-eohesHH8WFRUprDNyEREgqP6beG6htMeUYeCpkEgBCieCMme5r9zFWjzAJp//9S+Kub4rqE+jXe9Cp1a7IYIIA==",
+      "version": "9.13.0",
+      "resolved": "https://registry.npmjs.org/@eslint/js/-/js-9.13.0.tgz",
+      "integrity": "sha512-IFLyoY4d72Z5y/6o/BazFBezupzI/taV8sGumxTAVw3lXG9A6md1Dc34T9s1FoD/an9pJH8RHbAxsaEbBed9lA==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -2576,18 +2576,18 @@
       }
     },
     "node_modules/eslint": {
-      "version": "9.12.0",
-      "resolved": "https://registry.npmjs.org/eslint/-/eslint-9.12.0.tgz",
-      "integrity": "sha512-UVIOlTEWxwIopRL1wgSQYdnVDcEvs2wyaO6DGo5mXqe3r16IoCNWkR29iHhyaP4cICWjbgbmFUGAhh0GJRuGZw==",
+      "version": "9.13.0",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-9.13.0.tgz",
+      "integrity": "sha512-EYZK6SX6zjFHST/HRytOdA/zE72Cq/bfw45LSyuwrdvcclb/gqV8RRQxywOBEWO2+WDpva6UZa4CcDeJKzUCFA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.2.0",
         "@eslint-community/regexpp": "^4.11.0",
         "@eslint/config-array": "^0.18.0",
-        "@eslint/core": "^0.6.0",
+        "@eslint/core": "^0.7.0",
         "@eslint/eslintrc": "^3.1.0",
-        "@eslint/js": "9.12.0",
+        "@eslint/js": "9.13.0",
         "@eslint/plugin-kit": "^0.2.0",
         "@humanfs/node": "^0.16.5",
         "@humanwhocodes/module-importer": "^1.0.1",

--- a/dashboard/package.json
+++ b/dashboard/package.json
@@ -9,15 +9,15 @@
     "astro": "astro"
   },
   "dependencies": {
-    "@astrojs/check": "^0.9.4",
+    "@astrojs/check": "0.9.4",
     "astro": "4.16.6",
     "typescript": "5.6.3"
   },
   "devDependencies": {
-    "@typescript-eslint/parser": "^8.10.0",
-    "eslint": "^9.12.0",
-    "eslint-plugin-astro": "^1.3.0",
-    "eslint-plugin-jsx-a11y": "^6.10.0",
+    "@typescript-eslint/parser": "8.10.0",
+    "eslint": "9.13.0",
+    "eslint-plugin-astro": "1.3.0",
+    "eslint-plugin-jsx-a11y": "6.10.0",
     "prettier": "3.3.3",
     "prettier-plugin-astro": "0.14.1"
   },


### PR DESCRIPTION
# Pull Request

## Description

This change introduces a new GitHub Action for setting up TypeScript dependencies and updates existing workflows to use it. The key changes include:

1. Added a new action file `.github/actions/setup-typescript-dependencies/action.yml` which:
   - Sets up Node.js using the version specified in `dashboard/package.json`
   - Configures caching for npm dependencies
   - Sets up the Just command runner
   - Installs Node dependencies using a custom command

2. Updated `.github/dependabot.yml` to include the new TypeScript dependencies setup action in its monitored directories.

3. Modified `.github/workflows/code-quality.yml` to:
   - Rename the existing Python dependencies setup step for clarity
   - Replace the inline TypeScript setup steps with the new reusable action

These changes aim to improve consistency and reusability in the project's CI/CD setup, particularly for TypeScript-related tasks.

fixes #69