### PR TITLE
ci: Pin GitHub Actions versions in workflows

### DIFF
--- a/.github/actions/setup-python-dependencies/action.yml
+++ b/.github/actions/setup-python-dependencies/action.yml
@@ -9,7 +9,7 @@ runs:
       run: pipx install poetry==1.8.3
 
     - name: Install Python 3.13 with Poetry Cache
-      uses: actions/setup-python@v5
+      uses: actions/setup-python@v5.2.0
       with:
         python-version-file: "detector/pyproject.toml"
         cache: "poetry"

--- a/.github/actions/setup-typescript-dependencies/action.yml
+++ b/.github/actions/setup-typescript-dependencies/action.yml
@@ -5,7 +5,7 @@ runs:
   using: "composite"
   steps:
     - name: Set up Node.js
-      uses: actions/setup-node@v4
+      uses: actions/setup-node@v4.0.4
       with:
         node-version-file: "dashboard/package.json"
         cache: "npm"

--- a/.github/workflows/code-quality.yml
+++ b/.github/workflows/code-quality.yml
@@ -98,7 +98,7 @@ jobs:
           fetch-depth: 0
 
       - name: Check Markdown links
-        uses: UmbrellaDocs/action-linkspector@v1.2.2
+        uses: UmbrellaDocs/action-linkspector@v1.2.4
         with:
           github_token: ${{ secrets.GH_TOKEN }}
           config_file: .github/other-configurations/.linkspector.yml

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -23,9 +23,9 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4.2.1
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@v3
+        uses: github/codeql-action/init@v3.26.13
         with:
           languages: ${{ matrix.language }}
           queries: security-and-quality
       - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@v3
+        uses: github/codeql-action/analyze@v3.26.13

--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -13,4 +13,4 @@ jobs:
       - name: Checkout Repository
         uses: actions/checkout@v4.2.1
       - name: Dependency Review
-        uses: actions/dependency-review-action@v4
+        uses: actions/dependency-review-action@v4.3.4

--- a/.github/workflows/pull-request-checks.yml
+++ b/.github/workflows/pull-request-checks.yml
@@ -30,7 +30,7 @@ jobs:
     name: Labeller
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/labeler@v5
+      - uses: actions/labeler@v5.0.0
         with:
           repo-token: "${{ secrets.GITHUB_TOKEN }}"
           configuration-path: .github/other-configurations/labeller.yml


### PR DESCRIPTION
# Pull Request

## Description

This change updates several GitHub Actions and dependencies to their latest versions:

- `actions/setup-python` updated to v5.2.0
- `actions/setup-node` updated to v4.0.4
- `UmbrellaDocs/action-linkspector` updated to v1.2.4
- `github/codeql-action/init` and `github/codeql-action/analyze` updated to v3.26.13
- `actions/dependency-review-action` updated to v4.3.4
- `actions/labeler` updated to v5.0.0

These updates ensure that our CI/CD pipelines are using the latest versions of these actions, which may include bug fixes, performance improvements, and new features.

fixes #76