### PR TITLE
ci: Force colour output in detector run

### DIFF
--- a/.github/workflows/deploy-to-github-pages.yml
+++ b/.github/workflows/deploy-to-github-pages.yml
@@ -22,6 +22,8 @@ jobs:
 
       - name: Run Detector
         run: just detector::run
+        env:
+          FORCE_COLOR: "true" # Force log colour output
 
       - name: Install, build, and upload site
         uses: withastro/action@v3.0.0


### PR DESCRIPTION
# Pull Request

## Description

This change adds colour output to the log in the GitHub Actions workflow for deploying to GitHub Pages. Specifically, it sets the `FORCE_COLOR` environment variable to "true" for the "Run Detector" step, ensuring that the log output includes colour formatting. This enhancement improves the readability and visual clarity of the workflow logs.

fixes #93