### PR TITLE
chore: Update VS Code settings for Python and file exclusions

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -4,5 +4,14 @@
     "editor.codeActionsOnSave": {
       "source.fixAll": "explicit"
     }
+  },
+
+  "python.analysis.inlayHints.pytestParameters": true,
+  "files.exclude": {
+    ".ruff_cache": true,
+    ".pytest_cache": true,
+    "**/__pycache__": true,
+    "**/.ruff_cache": true,
+    "**/.pytest_cache": true
   }
 }


### PR DESCRIPTION
# Pull Request

## Description

This change updates the VS Code settings to enhance the development environment:

1. Enables pytest parameter inlay hints for improved test readability.
2. Configures file exclusions to hide cache directories and __pycache__ folders from the file explorer, reducing clutter in the workspace.

These modifications aim to improve the developer experience by providing more informative hints during testing and maintaining a cleaner project structure in the VS Code interface.

fixes #99