### PR TITLE
ci: Add coverage reporting to unit tests

### DIFF
--- a/.github/workflows/code-test.yml
+++ b/.github/workflows/code-test.yml
@@ -26,7 +26,7 @@ jobs:
         run: just detector::unit-test
 
       - name: Override Coverage Source Path for SonarCloud
-        run: sed -i "s/<source>\/home\/runner\/work\/tech-detective\/tech-detective<\/source>/<source>\/github\/workspace<\/source>/g" /home/runner/work/tech-detective/tech-detective/coverage.xml
+        run: sed -i "s/<source>\/home\/runner\/work\/tech-detective\/tech-detective<\/source>/<source>\/github\/workspace<\/source>/g" /home/runner/work/tech-detective/tech-detective/detector/coverage.xml
 
       - name: SonarCloud Scan
         uses: SonarSource/sonarcloud-github-action@v3.1.0

--- a/detector/detector.just
+++ b/detector/detector.just
@@ -12,7 +12,7 @@ run:
 
 # Runs unit tests
 unit-test:
-    poetry run pytest application
+    poetry run pytest application --cov=. --cov-report=xml
 
 # ------------------------------------------------------------------------------
 # Cleaning Commands

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -4,7 +4,7 @@ sonar.projectKey=JackPlowman_tech-detective
 sonar.sources=.
 
 sonar.python.version=3.13
-sonar.python.coverage.reportPaths=coverage.xml
+sonar.python.coverage.reportPaths=detector/coverage.xml
 
 sonar.coverage.exclusions=**/tests/**
 sonar.test.exclusions=**/tests/**


### PR DESCRIPTION
# Pull Request

## Description

Updates the unit test command to generate code coverage reports in XML format using pytest-cov. This enables better visibility into test coverage metrics and integration with code quality tools.

fixes #108