### PR TITLE
ci: Fix SonarCloud coverage source path

### DIFF
--- a/.github/workflows/code-test.yml
+++ b/.github/workflows/code-test.yml
@@ -26,7 +26,7 @@ jobs:
         run: just detector::unit-test
 
       - name: Override Coverage Source Path for SonarCloud
-        run: sed -i "s/<source>\/home\/runner\/work\/tech-detective\/tech-detective<\/source>/<source>\/github\/workspace<\/source>/g" /home/runner/work/tech-detective/tech-detective/detector/coverage.xml
+        run: sed -i "s/<source>\/home\/runner\/work\/tech-detective\/tech-detective\/detector<\/source>/<source>\/github\/workspace\/detector<\/source>/g" /home/runner/work/tech-detective/tech-detective/detector/coverage.xml
 
       - name: SonarCloud Scan
         uses: SonarSource/sonarcloud-github-action@v3.1.0


### PR DESCRIPTION
# Pull Request

## Description

This change modifies the `code-test.yml` workflow file to correct the source path in the SonarCloud coverage XML file. The `sed` command now specifically targets the `/detector` subdirectory in the source path, ensuring more accurate coverage reporting for the detector component.

The updated command replaces:
`/home/runner/work/tech-detective/tech-detective/detector`
with:
`/github/workspace/detector`

This adjustment will help SonarCloud correctly map the coverage data to the appropriate source files, improving the accuracy of the code analysis results.

fixes #114