### PR TITLE
ci: Refactor and add setup actions for dependencies

### DIFF
--- a/.github/actions/setup-test-dependencies/action.yml
+++ b/.github/actions/setup-test-dependencies/action.yml
@@ -1,4 +1,4 @@
-name: "Setup Python Dependencies"
+name: "Setup Test Dependencies"
 description: "Installs dependencies for the project"
 
 runs:
@@ -11,7 +11,7 @@ runs:
     - name: Install Python 3.13 with Poetry Cache
       uses: actions/setup-python@v5.2.0
       with:
-        python-version-file: "detector/pyproject.toml"
+        python-version-file: "tests/pyproject.toml"
         cache: "poetry"
 
     - name: Set up Just
@@ -19,4 +19,4 @@ runs:
 
     - name: Install Poetry Dependencies
       shell: bash
-      run: just detector::install
+      run: just tests::install

--- a/.github/actions/setup-typescript-dependencies/action.yml
+++ b/.github/actions/setup-typescript-dependencies/action.yml
@@ -1,4 +1,4 @@
-name: "Setup Dependencies"
+name: "Setup TypeScript Dependencies"
 description: "Installs dependencies for the project"
 
 runs:

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,6 +6,7 @@ updates:
       - "/"
       - ".github/actions/setup-python-dependencies"
       - ".github/actions/setup-typescript-dependencies"
+      - ".github/actions/setup-test-dependencies"
     commit-message:
       prefix: "deps(github-actions)"
     schedule:


### PR DESCRIPTION
# Pull Request

## Description

This change introduces a new GitHub Action for setting up test dependencies and refines the naming of existing setup actions. The modifications include:

1. Renamed the "Setup Dependencies" action to "Setup Python Dependencies" in the Python-specific setup action.
2. Created a new "Setup Test Dependencies" action that installs Poetry, sets up Python 3.13 with Poetry cache, installs Just, and sets up Poetry dependencies for tests.
3. Renamed the "Setup Dependencies" action to "Setup TypeScript Dependencies" in the TypeScript-specific setup action.
4. Updated the Dependabot configuration to include the new "Setup Test Dependencies" action in its monitored paths.

These changes improve the clarity and specificity of the setup actions, making it easier to manage dependencies for different parts of the project.

fixes #124