### PR TITLE
chore: Add pre-commit hook for tests directory

### DIFF
--- a/githooks/pre-commit-scripts/python.sh
+++ b/githooks/pre-commit-scripts/python.sh
@@ -6,3 +6,9 @@ if git diff --cached --name-only | grep -q "^detector/"; then
   just detector::install
   just detector::ruff-fix
 fi
+
+# Check if there are any changes in the watched folder
+if git diff --cached --name-only | grep -q "^tests/"; then
+  just tests::install
+  just tests::ruff-fix
+fi


### PR DESCRIPTION
# Pull Request

## Description

This change enhances the pre-commit hook for Python files by adding support for the `tests/` directory. The existing hook already processes files in the `detector/` directory, and this update extends similar functionality to the `tests/` folder.

When changes are detected in the `tests/` directory, the hook will now:
1. Install dependencies specific to the tests using `just tests::install`
2. Run the Ruff linter and apply automatic fixes using `just tests::ruff-fix`

This addition ensures that test files are also subject to consistent formatting and linting, maintaining code quality across both production and test code.

fixes #127