### PR TITLE
ci: Add size labels to pull request workflow

### DIFF
--- a/.github/workflows/pull-request-checks.yml
+++ b/.github/workflows/pull-request-checks.yml
@@ -14,6 +14,7 @@ on:
       ]
 
 permissions:
+  contents: read
   pull-requests: write
 
 jobs:
@@ -35,3 +36,13 @@ jobs:
           repo-token: "${{ secrets.GITHUB_TOKEN }}"
           configuration-path: .github/other-configurations/labeller.yml
           sync-labels: true
+
+  size-labels:
+    name: Add Size Labels
+    runs-on: ubuntu-latest
+    needs: labeller
+    steps:
+      - name: Add Size Labels
+        uses: pascalgn/size-label-action@v0.5.5
+        env:
+          GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"


### PR DESCRIPTION
# Pull Request

## Description

This change enhances the pull request checks workflow by adding a new job for size labelling. The workflow now includes:

1. A new `contents: read` permission to allow reading repository contents.
2. A new `size-labels` job that runs after the existing `labeller` job.
3. The `size-labels` job uses the `pascalgn/size-label-action@v0.5.5` action to automatically add size labels to pull requests based on their content.

These additions will help categorise pull requests by size, improving the review process and providing quick insights into the scope of changes.

fixes #134