### PR TITLE
ci: Add custom size labels to PR workflow

### DIFF
--- a/.github/workflows/pull-request-checks.yml
+++ b/.github/workflows/pull-request-checks.yml
@@ -31,7 +31,8 @@ jobs:
     name: Label Pull Request
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/labeler@v5.0.0
+      - name: Label Pull Request
+        uses: actions/labeler@v5.0.0
         with:
           repo-token: "${{ secrets.GITHUB_TOKEN }}"
           configuration-path: .github/other-configurations/labeller.yml
@@ -41,3 +42,13 @@ jobs:
         uses: pascalgn/size-label-action@v0.5.5
         env:
           GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
+          with:
+          sizes: >
+            {
+              "0": "XS",
+              "20": "S",
+              "50": "M",
+              "200": "L",
+              "500": "XL",
+              "1000": "XXL"
+            }


### PR DESCRIPTION
# Pull Request

## Description

This change enhances the pull request labelling process in the GitHub Actions workflow. It adds a name to the labeller step for improved readability and introduces size labelling for pull requests.

The size labelling action is configured with custom thresholds:
- XS: 0-19 lines
- S: 20-49 lines
- M: 50-199 lines
- L: 200-499 lines
- XL: 500-999 lines
- XXL: 1000+ lines

These updates will provide more detailed and automated categorisation of pull requests, helping to streamline the review process.

fixes #140