### PR TITLE
ci: Add end-to-end tests to code-test workflow

### DIFF
--- a/.github/actions/setup-test-dependencies/action.yml
+++ b/.github/actions/setup-test-dependencies/action.yml
@@ -1,6 +1,12 @@
 name: "Setup Test Dependencies"
 description: "Installs dependencies for the project"
 
+inputs:
+  install-playwright-dependencies:
+    description: "Install Playwright dependencies"
+    required: false
+    default: "false"
+
 runs:
   using: "composite"
   steps:
@@ -20,3 +26,8 @@ runs:
     - name: Install Poetry Dependencies
       shell: bash
       run: just tests::install
+
+    - name: Install Playwright Dependencies
+      shell: bash
+      if: ${{ inputs.install-playwright-dependencies == 'true' }}
+      run: just tests::playwright-install

--- a/.github/workflows/code-test.yml
+++ b/.github/workflows/code-test.yml
@@ -33,3 +33,20 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
+
+  end-to-end-test:
+    name: Run End to End Tests
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4.2.1
+        with:
+          fetch-depth: 0
+
+      - name: Setup Dependencies
+        uses: ./.github/actions/setup-test-dependencies
+        with:
+          install-playwright-dependencies: "true"
+
+      - name: Run End to End Tests
+        run: just tests::end-to-end-tests

--- a/tests/tests.just
+++ b/tests/tests.just
@@ -6,8 +6,12 @@
 install:
     poetry install
 
+# Install playwright dependencies
+playwright-install:
+    poetry run playwright install
+
 # End to End Tests
-end_to_end_tests:
+end-to-end-tests:
     poetry run pytest end_to_end
 
 # ------------------------------------------------------------------------------


### PR DESCRIPTION
# Pull Request

## Description

This change introduces a new end-to-end testing job to the existing GitHub Actions workflow. The new job, named "Run End to End Tests", is configured to run on the latest Ubuntu environment.

The job consists of three main steps:
1. Checkout the repository using actions/checkout@v4.2.1, ensuring all history is fetched.
2. Set up dependencies using a custom action located at ./.github/actions/setup-test-dependencies.
3. Execute the end-to-end tests using the command `just tests::end-to-end-tests`.

This addition enhances the overall testing strategy by incorporating end-to-end tests into the continuous integration pipeline, providing more comprehensive coverage and validation of the codebase.

fixes #132