### PR TITLE
chore: Configure file nesting in VS Code settings

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -5,7 +5,6 @@
       "source.fixAll": "explicit"
     }
   },
-
   "python.analysis.inlayHints.pytestParameters": true,
   "files.exclude": {
     ".ruff_cache": true,
@@ -13,5 +12,11 @@
     "**/__pycache__": true,
     "**/.ruff_cache": true,
     "**/.pytest_cache": true
+  },
+  "explorer.fileNesting.enabled": true,
+  "explorer.fileNesting.expand": false,
+  "explorer.fileNesting.patterns": {
+    "pyproject.toml": "__init__.py, poetry.lock, coverage.xml, .coverage, .gitignore",
+    "package.json": "package-lock.json, eslint.config.js, astro.config.mjs, .prettierrc.mjs, .gitignore"
   }
 }


### PR DESCRIPTION
# Pull Request

## Description

This change enhances the Visual Studio Code workspace settings by introducing file nesting configurations. The update enables file nesting, sets it to be collapsed by default, and defines nesting patterns for key project files.

Specifically, the following nesting patterns have been added:
- `pyproject.toml` will nest `__init__.py`, `poetry.lock`, `coverage.xml`, `.coverage`, and `.gitignore`
- `package.json` will nest `package-lock.json`, `eslint.config.js`, `astro.config.mjs`, `.prettierrc.mjs`, and `.gitignore`

These changes will help to declutter the file explorer, making it easier to navigate the project structure by grouping related files together.

fixes #150