### PR TITLE
chore: Temporarily only allow scraping of JackPlowman/tech-detective

### DIFF
--- a/detector/application/app.py
+++ b/detector/application/app.py
@@ -8,5 +8,13 @@ logger: stdlib.BoundLogger = get_logger()
 def generate_tech_report() -> str:
     """Generate a report on the technologies used in the repository."""
     repositories = retrieve_repositories()
-    for repository in repositories:
-        scrape_technologies(repository)
+
+    # Temporary code to test the scraper
+    tech_detective = next(
+        repository for repository in repositories if repository.full_name == "JackPlowman/tech-detective"
+    )
+    scrape_technologies(tech_detective)
+
+    # Reimplement this
+    # for repository in repositories:
+    #     scrape_technologies(repository) # noqa: ERA001

--- a/detector/application/tests/test_app.py
+++ b/detector/application/tests/test_app.py
@@ -9,9 +9,10 @@ FILE_PATH = "detector.application.app"
 @patch(f"{FILE_PATH}.retrieve_repositories")
 def test_generate_tech_report(mock_retrieve_repositories: MagicMock, mock_scrape_technologies: MagicMock) -> None:
     # Arrange
-    mock_retrieve_repositories.return_value = ["test"]
+    tech_detective = MagicMock(full_name="JackPlowman/tech-detective")
+    mock_retrieve_repositories.return_value = [tech_detective]
     # Act
     generate_tech_report()
     # Assert
     mock_retrieve_repositories.assert_called_once_with()
-    mock_scrape_technologies.assert_called_once_with("test")
+    mock_scrape_technologies.assert_called_once_with(tech_detective)


### PR DESCRIPTION
# Pull Request

## Description

This change modifies the `generate_tech_report` function in the `app.py` file to focus on testing the scraper functionality. The previous implementation, which scraped technologies for all repositories, has been temporarily commented out.

The new code selects a specific repository named "JackPlowman/tech-detective" from the list of repositories and applies the `scrape_technologies` function to this single repository. This targeted approach allows for more focused testing and debugging of the scraper functionality.

The original loop that processed all repositories has been preserved as a comment for future reimplementation, ensuring that the full functionality can be easily restored once testing is complete.