### PR TITLE
ci: Split GitHub Pages deployment workflow into stages

### DIFF
--- a/.github/workflows/code-test.yml
+++ b/.github/workflows/code-test.yml
@@ -33,20 +33,3 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
-
-  end-to-end-test:
-    name: Run End to End Tests
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v4.2.1
-        with:
-          fetch-depth: 0
-
-      - name: Setup Dependencies
-        uses: ./.github/actions/setup-test-dependencies
-        with:
-          install-playwright-dependencies: "true"
-
-      - name: Run End to End Tests
-        run: just tests::end-to-end-tests

--- a/.github/workflows/deploy-to-github-pages.yml
+++ b/.github/workflows/deploy-to-github-pages.yml
@@ -11,7 +11,8 @@ permissions:
   id-token: write
 
 jobs:
-  build:
+  run-detector:
+    name: Run Detector
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -26,14 +27,34 @@ jobs:
           FORCE_COLOR: "true" # Force log colour output
           GITHUB_REPOSITORY_OWNER: ${{ github.repository_owner }}
 
+      - name: Upload Detector Output File
+        uses: actions/upload-artifact@v4.4.3
+        with:
+          name: project-technologies-and-frameworks
+          path: project_technologies_and_frameworks.json
+
+  build-site:
+    name: Build Site
+    needs: run-detector
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4.2.1
+
+      - name: Download Detector Output File
+        uses: actions/download-artifact@v4.1.8
+        with:
+          name: project-technologies-and-frameworks
+
       - name: Install, build, and upload site
         uses: withastro/action@v3.0.0
         with:
           path: dashboard
           node-version: 22
 
-  deploy:
-    needs: build
+  deploy-site:
+    name: Deploy Site
+    needs: build-site
     runs-on: ubuntu-latest
     environment:
       name: github-pages
@@ -42,3 +63,21 @@ jobs:
       - name: Deploy to GitHub Pages
         id: deployment
         uses: actions/deploy-pages@v4.0.5
+
+  end-to-end-test:
+    name: Run End to End Tests
+    needs: deploy-site
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4.2.1
+        with:
+          fetch-depth: 0
+
+      - name: Setup Dependencies
+        uses: ./.github/actions/setup-test-dependencies
+        with:
+          install-playwright-dependencies: "true"
+
+      - name: Run End to End Tests
+        run: just tests::end-to-end-tests


### PR DESCRIPTION
# Pull Request

## Description

Restructures GitHub Actions workflows to improve deployment reliability and testing sequence. The end-to-end tests now run after site deployment, ensuring tests are performed against the live environment. 

The deployment workflow is split into distinct jobs:
- Detector execution with artefact storage
- Site building using the detector output
- GitHub Pages deployment
- End-to-end testing against the deployed site

This change ensures proper sequencing of deployment steps and validates the live site functionality through automated testing.

fixes #162