### PR TITLE
test: Disallow additional properties in project technologies schema

### DIFF
--- a/tests/schema_validation/project_technologies_and_frameworks_schema.json
+++ b/tests/schema_validation/project_technologies_and_frameworks_schema.json
@@ -1,5 +1,6 @@
 {
   "$schema": "http://json-schema.org/draft-04/schema#",
+  "additionalProperties": false,
   "type": "object",
   "properties": {
     "repositories": {


### PR DESCRIPTION
# Pull Request

## Description

Adds `additionalProperties: false` to the project technologies and frameworks schema to prevent unintended properties from being added to the schema object.

fixes #164