### PR TITLE
chore: Reorder Ruff fix commands in justfiles

### DIFF
--- a/detector/detector.just
+++ b/detector/detector.just
@@ -44,8 +44,8 @@ clean:
 
 # Fix all Ruff issues
 ruff-fix:
-    just detector::ruff-lint-fix
     just detector::ruff-format-fix
+    just detector::ruff-lint-fix
 
 # Check for Ruff issues
 ruff-lint:

--- a/tests/tests.just
+++ b/tests/tests.just
@@ -44,8 +44,8 @@ clean:
 
 # Fix all Ruff issues
 ruff-fix:
-    just tests::ruff-lint-fix
     just tests::ruff-format-fix
+    just tests::ruff-lint-fix
 
 # Check for Ruff issues
 ruff-lint:


### PR DESCRIPTION
# Pull Request

## Description

Reorders the Ruff fix commands in the justfiles to run formatting before linting. This ensures that any formatting changes are applied before lint fixes, preventing potential conflicts between the two operations.

The change affects both the detector and tests justfiles, where the `ruff-fix` recipe now executes `ruff-format-fix` before `ruff-lint-fix`.

fixes #166