### PR TITLE
test: Add Web Manifest Tests

### DIFF
--- a/tests/end_to_end/test_sitemap.py
+++ b/tests/end_to_end/test_sitemap.py
@@ -9,6 +9,7 @@ def test_sitemap_index_xml() -> None:
     # Act
     response = get(f"{PROJECT_URL}/sitemap-index.xml", timeout=2)
     # Assert
+    assert response.status_code == 200
     sitemap_index_element = fromstring(response.content)
     assert sitemap_index_element.tag == "{http://www.sitemaps.org/schemas/sitemap/0.9}sitemapindex"
     sitemap_element = sitemap_index_element.find("{http://www.sitemaps.org/schemas/sitemap/0.9}sitemap")

--- a/tests/end_to_end/test_web_manifest.py
+++ b/tests/end_to_end/test_web_manifest.py
@@ -1,0 +1,16 @@
+from requests import get
+
+from .utils.variables import PROJECT_URL
+
+
+def test_web_manifest() -> None:
+    """Test that the web manifest file is valid."""
+    # Act
+    response = get(f"{PROJECT_URL}/manifest.webmanifest", timeout=2)
+    # Assert
+    assert response.status_code == 200
+    assert response.headers["Content-Type"] == "application/manifest+json; charset=utf-8"
+    web_manifest = response.json()
+    assert web_manifest["name"] == "Tech Detective"
+    assert web_manifest["description"] == "What Technologies are used in my projects?"
+    assert web_manifest["start_url"] == "/tech-detective"


### PR DESCRIPTION
# Pull Request

## Description

This pull request includes updates to the end-to-end tests for the sitemap and web manifest functionalities. The changes ensure that the responses are valid and contain the expected content.

Improvements to end-to-end tests:

* [`tests/end_to_end/test_sitemap.py`](diffhunk://#diff-ba4856c27cd44d538a01cd1404d46a9484ddd19c8af461a306825aac238fc621R12): Added an assertion to check that the response status code is 200 in the `test_sitemap_index_xml` method.
* [`tests/end_to_end/test_web_manifest.py`](diffhunk://#diff-c6cd29441f6cdf1eea1705b1d0a85f84a832666d5b7f564ee3511472f717df49R1-R16): Added a new test `test_web_manifest` to validate the web manifest file, including checks for the response status code, content type, and specific fields in the manifest JSON.

fixes #129 
